### PR TITLE
Separate group header, configurable label/group/title and additional languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,58 @@
 
 Plugins for [CKEditor](https://ckeditor.com).
 
+## Configration
+
+```js
+// add it to the toolbar
+config.toolbar = [
+	['Bold', 'Italic', 'Underline'], 
+	...
+	['placeholder_select']
+];
+
+// configure from your config.js
+config.placeholder_select ) {
+	// define your placeholder tokens; just use the string name
+	// use jQuery or something here to get your tokens dynamically from somewhere...
+	placeholders = ['Firstname', 'Lastname', 'e-Mail'],
+	
+	// optionally define a custom format; default uses [[%placeholder%]]
+	// you can u se any format but ust include the %placeholder% in your custom format
+	format: '{{%placeholder%}}',
+	
+	// optionally you can change the label, group header and title independent from
+	// the selected language (or if your prefered language is not supported so far...)
+	label: 'My placeholders',
+	group: 'All placeholder we have',
+	title: 'Insert a placeholder'
+};
+
+// add it to your extra plugins, along with the richcombo
+config.extraPlugins = 'richcombo,placeholder_select';
+```
+
+If you need to support several areas with different placeholders, you can also 
+carry out the configuration when calling `CKEDITOR.replace(...)` instead of 
+implementing a complex logic in the CKEditors config.js:
+
+```js
+editor = CKEDITOR.replace('myEditor', {
+	contentsCss : 'mycontent.css',
+	...
+	placeholder_select : {
+		placeholders = ['Firstname', 'Lastname', 'e-Mail'],
+		label: 'Contactfields',
+		group: 'Available fields',
+		title: 'Insert from Contact'
+	},
+	...
+	resize_enabled : false
+});
+```
+
+
+
 ## Included Plugins:
 
 - [Placeholder Select](https://ckeditor.com/cke4/addon/placeholder_select)

--- a/placeholder_select/lang/de.js
+++ b/placeholder_select/lang/de.js
@@ -1,5 +1,6 @@
 CKEDITOR.plugins.setLang("placeholder_select", "de", {
-  dropdown_label: "Platzhalter einfügen",
+  dropdown_label: "Platzhalter",
+  dropdown_group: "verfügbare Platzhalter",
   dropdown_title: "Platzhalter einfügen",
   dropdown_voiceLabel: "Platzhalter einfügen",
 });

--- a/placeholder_select/lang/el.js
+++ b/placeholder_select/lang/el.js
@@ -1,5 +1,6 @@
 CKEDITOR.plugins.setLang('placeholder_select', 'el', {
     dropdown_label: 'Εισαγωγή πεδίου',
+    dropdown_group: 'Εισαγωγή πεδίου',
     dropdown_title: 'Εισαγωγή πεδίου',
     dropdown_voiceLabel: 'Εισαγωγή πεδίου'
 });

--- a/placeholder_select/lang/en.js
+++ b/placeholder_select/lang/en.js
@@ -1,5 +1,6 @@
 CKEDITOR.plugins.setLang('placeholder_select', 'en', {
-    dropdown_label: 'Insert placeholder',
+    dropdown_label: 'Placeholder',
+    dropdown_group: 'Available placeholder',
     dropdown_title: 'Insert placeholder',
     dropdown_voiceLabel: 'Insert placeholder'
 });

--- a/placeholder_select/lang/es.js
+++ b/placeholder_select/lang/es.js
@@ -1,0 +1,6 @@
+﻿CKEDITOR.plugins.setLang("placeholder_select_ext", "es", {
+  dropdown_label: "Marcador de Posición",
+  dropdown_group: "Marcador de Posición",
+  dropdown_title: "Marcador de Posición",
+  dropdown_voiceLabel: "Marcador de Posición",
+});

--- a/placeholder_select/lang/eu.js
+++ b/placeholder_select/lang/eu.js
@@ -1,0 +1,6 @@
+﻿CKEDITOR.plugins.setLang('placeholder_select', 'eu', {
+    dropdown_label: 'Leku-marka',
+    dropdown_group: 'Leku-marka',
+    dropdown_title: 'Leku-marka',
+    dropdown_voiceLabel: 'Leku-marka'
+});

--- a/placeholder_select/lang/fr.js
+++ b/placeholder_select/lang/fr.js
@@ -1,0 +1,6 @@
+﻿CKEDITOR.plugins.setLang("placeholder_select", "fr", {
+  dropdown_label: "Espace réservé",
+  dropdown_group: "Espace réservé",
+  dropdown_title: "Espace réservé",
+  dropdown_voiceLabel: "Espace réservé",
+});

--- a/placeholder_select/lang/it.js
+++ b/placeholder_select/lang/it.js
@@ -1,0 +1,6 @@
+﻿CKEDITOR.plugins.setLang('placeholder_select', 'it', {
+    dropdown_label: 'Crea segnaposto',
+    dropdown_group: 'Crea segnaposto',
+    dropdown_title: 'Crea segnaposto',
+    dropdown_voiceLabel: 'Crea segnaposto'
+});

--- a/placeholder_select/plugin.js
+++ b/placeholder_select/plugin.js
@@ -11,7 +11,7 @@
  */
 
 CKEDITOR.plugins.add("placeholder_select", {
-  lang: ["en", "de", "el"],
+  lang: ["de", "el", "en", "es", "eu", "fr", "it"],
   requires: ["richcombo"],
   init: function (editor) {
     //  array of placeholders to choose from that'll be inserted into the editor
@@ -46,9 +46,10 @@ CKEDITOR.plugins.add("placeholder_select", {
 
     // add the menu to the editor
     editor.ui.addRichCombo("placeholder_select", {
-      label: editor.lang.placeholder_select.dropdown_label,
-      title: editor.lang.placeholder_select.dropdown_title,
-      voiceLabel: editor.lang.placeholder_select.dropdown_voiceLabel,
+      label: config.label || editor.lang.placeholder_select.dropdown_label,
+      group: config.group || editor.lang.placeholder_select.dropdown_group,
+      title: config.title || editor.lang.placeholder_select.dropdown_title,
+      voiceLabel: config.voiceLabel || editor.lang.placeholder_select.dropdown_voiceLabel,
       className: "cke_format",
       multiSelect: false,
       panel: {
@@ -59,7 +60,7 @@ CKEDITOR.plugins.add("placeholder_select", {
       },
 
       init: function () {
-        this.startGroup(this.label);
+        this.startGroup(this.group);
         for (var i in placeholders) {
           this.add(placeholders[i][0], placeholders[i][1], placeholders[i][2]);
         }


### PR DESCRIPTION
- The text of the group header of the placeholder dropdown list can be changed independently   
  from the label (so its possible to use a shorter label that fits on the button)
- All texts/labels can be changed via configuration (e.g. for anyone who needs a different language 
  than the ones available so far...)
  -> see additional documentation in the [readme.md]
- added languages: "es", "eu", "fr", "it"

> **Attention**
> If you include this pull request in the master branch, please also **publish the current version on 
> CKEditor** so that the latest version is taken into account by the next build.  
> Unfortunately, the current Build 4.20 still contains an extremely old version (**Updated: 23 Jun 2016**).   
> [placeholder_select](https://ckeditor.com/cke4/addon/placeholder_select)  
> Since i havn't published any plugin so far, I don't know what the workflow at CKEditor is, that a new 
> version is  included in the official build.  
> *I guess it also needs to be released via* `Submit plugin release`. If you do so, please just increase the 
> version number (current 0.1) as well ;-)